### PR TITLE
auto for not committed types and use decltype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
+project(CMakeBuild)
+
+
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+message(STATUS "Is the C++ compiler loaded? ${CMAKE_CXX_COMPILER_LOADED}")
+if(CMAKE_CXX_COMPILER_LOADED)
+  message(STATUS "The C++ compiler ID is: ${CMAKE_CXX_COMPILER_ID}")
+  message(STATUS "Is the C++ from GNU? ${CMAKE_COMPILER_IS_GNUCXX}")
+  message(STATUS "The C++ compiler version is: ${CMAKE_CXX_COMPILER_VERSION}")
+endif()
+
+add_subdirectory(src)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(modernCPP main.cpp)
+
+add_subdirectory(core-features)
+
+target_link_libraries(modernCPP 
+      PRIVATE core-features
+)

--- a/src/core-features/CMakeLists.txt
+++ b/src/core-features/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(core-features "")
+
+target_sources(core-features 
+      PRIVATE ${CMAKE_CURRENT_LIST_DIR}/useAuto.cpp
+      PUBLIC ${CMAKE_CURRENT_LIST_DIR}/useAuto.h
+)
+
+target_include_directories(core-features 
+      PUBLIC ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/src/core-features/useAuto.cpp
+++ b/src/core-features/useAuto.cpp
@@ -1,0 +1,34 @@
+#include "useAuto.h"
+#include <string_view>
+#include <iostream>
+
+template <typename T>
+constexpr auto type_name() {
+  std::string_view name, prefix, suffix;
+#ifdef __clang__
+  name = __PRETTY_FUNCTION__;
+  prefix = "auto type_name() [T = ";
+  suffix = "]";
+#elif defined(__GNUC__)
+  name = __PRETTY_FUNCTION__;
+  prefix = "constexpr auto type_name() [with T = ";
+  suffix = "]";
+#elif defined(_MSC_VER)
+  name = __FUNCSIG__;
+  prefix = "auto __cdecl type_name<";
+  suffix = ">(void)";
+#endif
+  name.remove_prefix(prefix.size());
+  name.remove_suffix(suffix.size());
+  return name;
+}
+
+void useAuto::notCommitSpecificType()
+{
+  auto iValue = 100;
+  auto fValue = 2.3;
+  auto myDouble = 2.3;
+  auto str = "this is string";
+
+  std::cout<<type_name<decltype(str)>()<<std::endl;
+}

--- a/src/core-features/useAuto.h
+++ b/src/core-features/useAuto.h
@@ -1,0 +1,6 @@
+//Almost always auto
+class useAuto{
+public:
+  void notCommitSpecificType();
+
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,15 @@
+#include "core-features/useAuto.h"
+#include <iostream>
+
+int main()
+{
+  useAuto autoObj;
+  autoObj.notCommitSpecificType();
+}
+
+// $ docker run -it devcafe/cmake-cookbook_ubuntu-18.04
+// $ git clone https://github.com/dev-cafe/cmake-cookbook.git
+// $ cd cmake-cookbook
+// $ pipenv install --three
+// $ pipenv run python testing/collect_tests.py 'chapter-*/recipe-*'
+


### PR DESCRIPTION
use of auto. for expressions which are not committed

1. auto name = expression .
2. use decltype for argument deduction used by auto in above expression.
3. Added CMakeLists for multi directories and built project with C++ 14 compiler version.